### PR TITLE
implementation of methods to examination of the game

### DIFF
--- a/src/rules/game.rs
+++ b/src/rules/game.rs
@@ -456,7 +456,7 @@ impl Game {
         self.ko_point = None;
     }
    
-    /// Load the game from moves_history by desgnating move number (0 is the first move).
+    /// Load the game from moves_history by desgnating move number (1 is the first move).
     /// self.goban will be updated.
     /// self.moves_history and self.history will not be updated. 
     #[cfg(feature = "history")]
@@ -464,7 +464,7 @@ impl Game {
         self.initialize();
         if move_num > 0 {
             for mv in self.moves_history[0..move_num].to_vec() {
-                self.play(mv);
+                self.__play__(mv);
             }
         }
     }

--- a/src/rules/game_builder.rs
+++ b/src/rules/game_builder.rs
@@ -110,12 +110,15 @@ impl GameBuilder {
             passes: 0,
             prisoners: (0, 0),
             outcome: self.outcome,
+            move_num: 0,
             turn: self.turn,
             komi: self.komi,
             rule: self.rule,
             handicap: self.handicap_points.len() as u8,
             #[cfg(feature = "history")]
             history: vec![],
+            #[cfg(feature = "history")]
+            moves_history: vec![],
             hashes: Default::default(),
             last_hash: 0,
             ko_point: None,


### PR DESCRIPTION
# What has been added
- `goban::rules::game::Game::move_num`
- `goban::rules::game::Game::moves_history` // Record of stone moves (not record goban states or other parameters)
- `goban::rules::game::Game::initialize()`
- `goban::rules::game::Game::update_moves_history()`
- `goban::rules::game::Game::load_by_movenum`
- `goban::rules::game::Game::move_backward()`
- `goban::rules::game::Game::move_forward()`

# Purpose
I think it is beneficial for users if `goban::pieces::goban::Goban` is updatable along the history, because go-players often examine their games by repeatably moving backward, forward, or making a new branch from a certain point. 
Newly-added methods allow library users to freely move in the game history and start new game branch,
Both `move_backward()` and `move_forward()` update `goban::pieces::goban::Goban`, but do not update `moves_history`.
When users use `goban::rules::game::Game::play(play)`, the `moves_history` will be updated. Therefore, the users can start newly branched game, like below:
```
use goban;
use rand::seq::IteratorRandom;

fn main () {

    let mut g = goban::rules::game::Game::builder()
    .size((19,19))
    .rule(goban::rules::Rule::Chinese)
    .build().unwrap();

    let mut i = 4;
    while !g.is_over() && i != 0 {
        g.play(
            g.legals()
                .choose(&mut rand::thread_rng())
                .map(|point| goban::rules::Move::Play(point.0,point.1))
                .unwrap());
        i -= 1;
        g.display_goban();
    }

    for _j in 0..5 {
        g.move_backward();
        g.display_goban();
    }
    
    for _k in 0..2 {
        g.move_forward();
        g.display_goban();
    }

    let mut i = 6;
    while !g.is_over() && i != 0 {
        g.play(
            g.legals()
                .choose(&mut rand::thread_rng())
                .map(|point| goban::rules::Move::Play(point.0,point.1))
                .unwrap());
        i -= 1;
        g.display_goban();
    }

}
```

# Points to be discussed
- Are these features much to this crate?
- Mixture of `goban::rules::game::Game::history` and `goban::rules::game::Game::moves_history` may be not smart. However, (in my understanding) `goban::rules::game::Game::history` contains only goban states, not all game states (like prisoners or ko-point). Therefore, it is not suitable for the above-mentioned purpose.
- Instead of recording `moves_history`, we have an option to record `goban::rules::game::Game` directly. Maybe the former is more memory-efficient, and the later is more CPU-efficient. Which do you think better?
- I do not have good idea for the name of `goban::rules::game::Game::__play__` ......
- My Rust code may be still awkward.